### PR TITLE
Made the license mentioned in the contributing guide more specific.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 
 ## Any contributions you make will be under the GNU v3 Software License
 
-In short, when you submit code changes, your submissions are understood to be under the same GNU v3 license that covers the project. Feel free to contact the maintainers if that's a concern.
+In short, when you submit code changes, your submissions are understood to be under the same LGPL-3.0 license that covers the project. Feel free to contact the maintainers if that's a concern.
 
 ## Report bugs using Github's [issues](https://github.com/realandrew/base-html5-template/issues)
 
@@ -48,4 +48,4 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under its GNU v3 License.
+By contributing, you agree that your contributions will be licensed under its LGPL-3.0 license.


### PR DESCRIPTION
Specified the license in CONTRIBUTING.md as "LGPL-3.0" to be more specific than the "GNU v3" that was previously listed.